### PR TITLE
removing `nus.edu.sg` from list

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -798,7 +798,6 @@ nowhere.org
 nowmymail.com
 nubescontrol.com
 nurfuerspam.de
-nus.edu.sg
 nwldx.com
 ny7.me
 o7i.net


### PR DESCRIPTION
`nus.edu.sg` is a legit email address provider (National University of Singapore).