### PR TITLE
DiscordMail.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -824,6 +824,7 @@ discard.tk
 discard-email.cf
 discardmail.com
 discardmail.de
+discordmail.com
 disign-concept.eu
 disign-revelation.com
 dispo.in


### PR DESCRIPTION
See also http://discordmail.com. Note that since Discord (The service Discord Mail relies on) can be registered without an email, it is possible to register many DiscordMail accounts in this way too.