### PR TITLE
Add minimal package & composer.JSON to aid developers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "wesbos/burner-email-providers",
+    "description": "A list of burner email providers.",
+    "license": "proprietary",
+    "authors": [ { "name": "Wes Bos & contributors" } ],
+    "support": {
+        "source": "https://github.com/wesbos/burner-email-providers"
+    },
+    "keywords": [ "email" ],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+    "private": true,
+    "name": "burner-email-providers",
+    "version": "1.0.0-RC",
+    "description": "A list of burner email providers.",
+    "license": "UNLICENSED",
+    "author": "Wes Bos & contributors",
+    "repository": "https://github.com/wesbos/burner-email-providers",
+    "files": [
+        "emails.txt"
+    ],
+    "keywords": [ "email" ]
+}


### PR DESCRIPTION
Hi Wes & collaborators,

I've just started using this repo on [a project](https://github.com/IET-OU/cloudengine)... _(Thank you - v. useful!)_

Given that a lot of developers use dependency managers, would it be OK to add the necessary files to aid integration with popular languages?

I've added minimal `package.json` and `composer.json` to support Node/NPM & PHP respectively.

Note, in neither case does the project have to be submitted to the dependency manager's repository ([NPM](https://npmjs.com/) or [Packagist](https://packagist.org/)), though of course they could be.

As no license is declared, I've put _"proprietary"_ and _"UNLICENSED"_ for the `license` field. Of course, change if you want to put an explicit license.

I hope this is useful.

Thank you,


Nick