### PR TITLE
Remove sneakemail domains

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -2955,9 +2955,7 @@ smsforum.ro
 smtp99.com
 smwg.info
 snakemail.com
-sneakemail.com
 sneakmail.de
-snkmail.com
 socialfurry.org
 social-mailer.tk
 sofimail.com


### PR DESCRIPTION
sneakemail.com is a paid email forwarding service and should not be blocked.  They are not "burner" addresses, and mail sent to them will be delivered normally and not bounce.

We use these addresses so we have control over what mail we get.  If a server gets hacked (which seems to be a daily occurrence lately) or sells our address to spammers, we can shut down the address and not worry about the breach.  By default, we will still read legitimate email you send us, though.

Similar rationale to https://github.com/wesbos/burner-email-providers/issues/24

For an example of how this service is used, see [How SneakEmail Once Saved Me From A Phishing Attack](https://www.donationcoder.com/forum/index.php?topic=43297.0)