### PR TITLE
Allow 126.com / sina.com / sohu.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -49,7 +49,6 @@
 10x9.com
 11top.xyz
 123-m.com
-126.com
 12hosting.net
 12houremail.com
 12minutemail.com
@@ -2977,7 +2976,6 @@ siliwangi.ga
 simpleitsecurity.info
 simscity.cf
 sin.cl
-sina.com
 sinda.club
 sinfiltro.cl
 singlespride.com
@@ -3030,7 +3028,6 @@ sofort-mail.de
 sofortmail.de
 softpls.asia
 sogetthis.com
-sohu.com
 sohu.net
 soioa.com
 soisz.com


### PR DESCRIPTION
Sohu is No 13 in China https://www.similarweb.com/website/sohu.com
Sina is No 28 https://www.similarweb.com/website/sina.com.cn
126.com No 256 https://www.similarweb.com/website/126.com

According to this https://www.quora.com/Who-are-the-top-5-email-providers-in-China-Are-there-any-stats-around-their-marketshare, all three seem to be top 10 email providers in China.

A bit tricky to figure out if they allow temporary emails to be created.
Has anyone reported application layer attacks coming from those domains?