### PR TITLE
update list to include sfgov.net (real sf gov domain is sfgov.org)

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -2934,6 +2934,7 @@ sexical.com
 sexyalwasmi.top
 sezet.com
 sfamo.com
+sfgov.net
 sfmail.top
 shapoo.ch
 sharedmailbox.org


### PR DESCRIPTION
We've been seeing a slew of instances of burner emails that look like official San Francisco government accounts coming from `sfgov.net` instead of `sfgov.org`