### PR TITLE
Remove naver.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -2442,7 +2442,6 @@ napalm51.ml
 napalm51.tk
 nationalgardeningclub.com
 naturalious.com
-naver.com
 nbox.notif.me
 nctuiem.xyz
 negated.com


### PR DESCRIPTION
Naver.com is not disposable, as it is used regularly by Korean.