### PR TITLE
Remove tryninja.io from emails list

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -3497,7 +3497,6 @@ trollproject.com
 tropicalbass.info
 trungtamtoeic.com
 tryalert.com
-tryninja.io
 tryzoe.com
 ts-by-tashkent.cf
 ts-by-tashkent.ga


### PR DESCRIPTION
`tryninja.io` appears on the list but it doesn't provide throw away email addresses. The email addresses are real and forward to your personal inbox. They are used for privacy rather than spam/quick signup.