### PR TITLE
Remove tryninja.io from emails list

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -3497,7 +3497,6 @@ trollproject.com
 tropicalbass.info
 trungtamtoeic.com
 tryalert.com
-tryninja.io
 tryzoe.com
 ts-by-tashkent.cf
 ts-by-tashkent.ga


### PR DESCRIPTION
Hi, I understand  the intent of this list, however

- tryninja.io forwards to a real email address and doesn't bounce (if the person disables the burner address the email will simply not forward to their personal inbox but does not bounce)
- tryninja.io has abuse and spam filters 
- every email address is attached to a specific logged in user and is tracable by the admin (you can report an abuse and and we can block the abusive users)

As our service wouldn't drive up bounces or hurt deliverability any more than the other service providers such as google where people can easily get multiple mail addresses.

The service is used for privacy and protecting users from spam/data breaches/identity theft and it seems that it should't be on this list. 

tryninja.io doesn't provide "disposable email addresses" aka throwaway mailboxes in the sense like mailinator and co.  Our email addresses do not expire and there is one account per person which can have more than one address and the person owns the email addresses which stay around attached to that account. They can be limited in the number of emails they accept but normally, if a person subscribes to the email address to a mailing list they will just allow indefinite mails.

The email address would only really be disposable if it was sold to a spammer and the user would shut it down. Similar to the way google mainaccount+filter@gmail.com addresses work.

Here is a full definition of what Disposable email addressing means, what it does, how it works and the benefits of using it https://en.wikipedia.org/wiki/Disposable_email_address

Let me know what you think