### PR TITLE
Remove `dt.com` from emails.txt

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -1060,7 +1060,6 @@ dropmail.me
 drynic.com
 dsiay.com
 dspwebservices.com
-dt.com
 dtools.info
 duam.net
 duck2.club


### PR DESCRIPTION
My security team at ezCater has verified that `dt.com` is a legit email domain now for a company called Direct Travel (https://www.dt.com/). I'm hoping we can get this value removed from this list?