### PR TITLE
removed qq.com - not disposable

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -2944,7 +2944,6 @@ qisdo.com
 qisoa.com
 qj97r73md7v5.com
 qoika.com
-qq.com
 qq.my
 qs2k.com
 qsl.ro


### PR DESCRIPTION
Removed qq.com as this is not a burner email provider - it's a very common Chinese domain.