### PR TITLE
Remove brainonfire.net

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -704,7 +704,6 @@ boxformail.in
 boximail.com
 boxmail.co
 boxtemp.com.br
-brainonfire.net
 brandallday.net
 brasx.org
 bratwurst.dnsabr.com


### PR DESCRIPTION
`brainonfire.net` is just my personal domain name, and has never hosted disposable email.

About 10 years ago, I had `open.brainonfire.net` aliased to mailinator, but that subdomain hasn't existed for *years* now, and it was always just the subdomain.

I see it was added in commit https://github.com/wesbos/burner-email-providers/commit/636ba033fd854d601ae7c62391eb7994b85a68d6 -- I don't know what your source was, but consider this an indicator that it likely had a lot of false positives in it!