### PR TITLE
gmx.es, gmx.com are not disposable

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -41730,10 +41730,8 @@ gmsdfhail.com
 gmsdluxx.com
 gmsinvest.ru
 gmssail.com
-gmx.com
 gmx.dns-cloud.net
 gmx.dnsabr.com
-gmx.es
 gmx.fr.nf
 gmx1mail.top
 gmxip8vet5glx2n9ld.cf


### PR DESCRIPTION
They belong to https://en.wikipedia.org/wiki/GMX_Mail, a major portal in Germany. I'm a customer of gmx.