### PR TITLE
Adding nedoz.com to the list

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -67278,6 +67278,7 @@ nedf.de
 nediyor.net
 nediyor.org
 nedmin.com
+nedoz.com
 nedrk.com
 neds.cards
 neds.cash


### PR DESCRIPTION
nedoz.com is a domain under tempmail.com