### PR TITLE
Replaced DED with go-burner-email-providers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Please send a PR with any new ones you find.
 
 ### Go
 
-* [DED](https://github.com/namreg/ded) (__Reported not working__)
+* [go-burner-email-providers](https://github.com/lindell/go-burner-email-providers)
 
 ### NodeJs
 


### PR DESCRIPTION
Since DED is dead and the owner hasn't responded to any request to fix it for over a year, I created a similar go package (that is actually working).

This PR replaces the link to the working library.