### PR TITLE
Add sort check on pull requests

### DIFF
--- a/.github/workflows/sort-check.yaml
+++ b/.github/workflows/sort-check.yaml
@@ -1,5 +1,5 @@
 name: Sort check
-on: [push]
+on: [push, pull_request]
 
 jobs:
   sort-check:

--- a/emails.txt
+++ b/emails.txt
@@ -40387,10 +40387,10 @@ firema.cf
 firema.ga
 firema.ml
 firema.tk
-firemailbox.club
 firemail.cc
 firemail.org.ua
 firemail.uz.ua
+firemailbox.club
 firemansbalm.com
 firemanscream.com
 firemapprints.com


### PR DESCRIPTION
It seems like the sort check does not run if the PR comes from another repo. This fixes it. And fixes that the last commit was not sorted.