### PR TITLE
removed mail2world

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -65204,7 +65204,6 @@ mail2nowhere.tk
 mail2paste.com
 mail2rss.org
 mail2tor.com
-mail2world.com
 mail3.activelyblogging.com
 mail3.drama.tw
 mail3.top


### PR DESCRIPTION
Mail2World looks like a legitimate provider, albeit a free system - but we have users using it who no longer are receiving our emails.