### PR TITLE
Add thefmail.com domain

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -101124,6 +101124,7 @@ theflanneleffect.com
 theflatwater.com
 theflavr.com
 theflexbelt.info
+thefmail.com
 thefocusfolks.com
 theforexdivision.com
 theforgotten-soldiers.com


### PR DESCRIPTION
This is a domain used for disposable emails, according to https://www.ipqualityscore.com/domain-reputation/thefmail.com