### PR TITLE
Add goposts.site domain

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -45756,6 +45756,7 @@ goplmega.tk
 goplmega1.tk
 gopo.email
 gopoker303.org
+goposts.site
 gopowerlevel.com
 goproaccessories.us
 goprovs.com


### PR DESCRIPTION
According to https://www.ipqualityscore.com/domain-reputation/goposts.site this is a disposable email site.