### PR TITLE
Add dizaer.ru

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -32436,6 +32436,7 @@ diypostconpi.ml
 diytaxes.com
 diywithpaul.com
 diz-store.online
+dizaer.ru
 dizain-gox.ru
 dizibb.org
 dizifenomeny.xyz


### PR DESCRIPTION
Hi.

Recently I've discovered a ton of fake accounts from `dizaer.ru` domain created on my site, like ones below:
allaripmuff1981@dizaer.ru
anpsychgocou1962@dizaer.ru
cantasoti1961@dizaer.ru
cinaschfatols1965@dizaer.ru
crisradownrot1973@dizaer.ru
factbarsapar1989@dizaer.ru
feturdimos1977@dizaer.ru
furbesusra1965@dizaer.ru
glucocliro1975@dizaer.ru
hobbgroupwebsma1975@dizaer.ru
humlireaspe1970@dizaer.ru
ikallulens1971@dizaer.ru
joydicsudab1986@dizaer.ru
kaiwarzellfeck1989@dizaer.ru
leofinbanigs1963@dizaer.ru
maglirade1962@dizaer.ru
pitahydne1959@dizaer.ru
quichloruner1961@dizaer.ru
quimocanan1957@dizaer.ru
retadipat1971@dizaer.ru
rougguibenchhi1966@dizaer.ru
sarytacout1957@dizaer.ru
spawdentome1965@dizaer.ru
syletodep1964@dizaer.ru
teanuproumob1957@dizaer.ru
therscamoti1968@dizaer.ru
tiodasemu1969@dizaer.ru
tiolimadis1950@dizaer.ru
tricerranews1983@dizaer.ru
turnponrorrge1951@dizaer.ru
vestremoldi1987@dizaer.ru

According to https://www.stopforumspam.com/domain/dizaer.ru other sites are facing the same issue, registration rate increased since May 2021.