### PR TITLE
Add ualusa.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -105706,6 +105706,7 @@ uagtl.us
 uagyp.com
 uajgqhgug.pl
 ualmail.com
+ualusa.com
 uamail.com
 uamtlrlr.shop
 uannfamd.ru


### PR DESCRIPTION
Hi.

Recently I've discovered a some fake accounts from `ualusa.com` domain created on my site, like ones below:
eduardo_shimp@ualusa.com
ezequiel.moeller@ualusa.com
fae_delany@ualusa.com
joycelyn_eade33@ualusa.com
keeley-vessels79@ualusa.com
mamie.speer20@ualusa.com

According to https://www.stopforumspam.com/domain/ualusa.com other sites are facing the same issue, registration rate increased since the beginning of 2021.