### PR TITLE
Add efastes.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -35459,6 +35459,7 @@ ef9ppjrzqcza.ml
 ef9ppjrzqcza.tk
 efacs.net
 efago.space
+efastes.com
 efasttrackwatches.com
 efatt2fiilie.ru
 efcdn3.info


### PR DESCRIPTION
Hi.

Recently I've discovered a some fake accounts from `den.efastes.com` or `makao.efastes.com` domains created on my site, like ones below:
a.hudnickiy@den.efastes.com
a.sviridov@makao.efastes.com
d.denisovich@den.efastes.com
i.petrovich@den.efastes.com
k.svanin@den.efastes.com
s.golovenkin@den.efastes.com
s.petrovich@makao.efastes.com
v.dubova@makao.efastes.com

According to https://www.stopforumspam.com/domain/den.efastes.com and https://www.stopforumspam.com/domain/makao.efastes.com other sites are facing the same issue, registration rate increased since February 2021.