### PR TITLE
Add enersets.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -36732,6 +36732,7 @@ energysavvy.org
 energysavvyoptix.com
 energywatch.mobi
 energywidetimes.com
+enersets.com
 enestmep.com
 enevthom.gq
 enevthom.ml


### PR DESCRIPTION
Hi.

Recently I've discovered a some fake accounts from `*.enersets.com` domains created on my site, like ones below:
d.fomin@max.enersets.com
d.hromov@max.enersets.com
d.semenov@max.enersets.com
m.viktorovna@jodas.enersets.com
m.voytenko@denis.enersets.com
p.gromyko@max.enersets.com
s.folomkin@max.enersets.com

According to https://www.stopforumspam.com/domain/max.enersets.com (and searching by other subdomains), other sites are facing the same issue, registration rate increased since April 2021.