### PR TITLE
Add vipcherry.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -109069,6 +109069,7 @@ vip9stn.xyz
 vipattendance.com
 vipbd4.info
 vipbet5.biz
+vipcherry.com
 vipchristianlouboutindiscount.com
 vipclub.icu
 vipcodes.info


### PR DESCRIPTION
Hi.

Recently I've discovered a some fake accounts from `vipcherry.com` domain created on my site, like ones below:
ava-gertrude48@vipcherry.com
christiane_hedditch93@vipcherry.com
madeline.juan23@vipcherry.com
stacia_hallen64@vipcherry.com

According to https://www.stopforumspam.com/domain/vipcherry.com other sites are facing the same issue, registration rate increased since the beginning of 2021.