### PR TITLE
Add hammerhandz.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -47730,6 +47730,7 @@ hammbur.com
 hammel-shredder-repair.com
 hammer53.website
 hammerdin.com
+hammerhandz.com
 hammerthor.solutions
 hamonclub.ru
 hampanel.com


### PR DESCRIPTION
Hi.

Recently I've discovered a some fake accounts from `*.hammerhandz.com` domains created on my site, like ones below:
danniellepauley@int.hammerhandz.com
genewolf@int.hammerhandz.com
lucilechomley40@int.hammerhandz.com
malcolmwhitham44@int.hammerhandz.com
tanjameehan@int.hammerhandz.com
catch@extra.hammerhandz.com

According to https://www.stopforumspam.com/domain/int.hammerhandz.com (and other subdomains) other sites are facing the same issue, registration rate increased since May 2021.