### PR TITLE
Add usamami.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -107148,6 +107148,7 @@ usamail.cf
 usamail.com
 usamail.gq
 usamail.ml
+usamami.com
 usaohionewyears.com
 usaonline.biz
 usaoppo.com


### PR DESCRIPTION
Hi.

Recently I've discovered a some fake accounts from `usamami.com` domain created on my site, like ones below:
milagro_foulds80@usamami.com
renato_chandler@usamami.com
sherry-crutchfield@usamami.com
susanne.messina@usamami.com

According to https://www.stopforumspam.com/domain/usamami.com other sites are facing the same issue, registration rate increased since the beginning of 2021.