### PR TITLE
Add frequiry.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -42172,6 +42172,7 @@ frenteadventista.com
 frenzybudgeter.com
 frenzytiger.com
 frequential.info
+frequiry.com
 freresphone.com
 fresclear.com
 fresco-pizzeria-ballybrittas.com


### PR DESCRIPTION
Hi.

Recently I've discovered a some fake accounts from `tree.frequiry.com` domain created on my site, like ones below:
jeannaxiong75@tree.frequiry.com
sofiahuber85@tree.frequiry.com

According to https://www.stopforumspam.com/domain/tree.frequiry.com (and searching for other subdomains like edu.frequiry.com) other sites are facing the same issue, registration rate increased since May 2021.