### PR TITLE
Remove cock.li domains

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -3759,7 +3759,6 @@
 41y.ru
 4204445.com
 420baby.store
-420blaze.it
 420ico.bid
 420pure.com
 42380398.xyz
@@ -8209,7 +8208,6 @@ aaaf.ru
 aaaip.org
 aaamail.online
 aaamc.net
-aaathats3as.com
 aaaw45e.com
 aabagfdgks.net
 aabamian.site
@@ -10177,7 +10175,6 @@ airjordansstocker.com
 airjuniors.info
 airknox.com
 airlagu.me
-airmail.cc
 airmail.tech
 airmailbox.website
 airmailhub.com
@@ -26500,7 +26497,6 @@ cobratandooritakeaway.com
 cobrei.app
 cocabooka.site
 cocacomi.com
-cocaine.ninja
 cocainerehab.center
 coccx1ajbpsz.cf
 coccx1ajbpsz.ga
@@ -26513,9 +26509,6 @@ cochisi.gq
 cochisi.tk
 cochranmail.men
 cocinacadadia.com
-cock.email
-cock.li
-cock.lu
 cocknass.com
 cockpitdigital.com
 coclaims.com
@@ -28794,7 +28787,6 @@ culvercitydoctors.com
 culvercityrealestateagents.com
 cum.camera
 cum.sborra.tk
-cumallover.me
 cumangeblog.net
 cumanuallyo.com
 cumbeeclan.com
@@ -31680,8 +31672,6 @@ dickdoc.net
 dickdoc.org
 dickmorrisservice.com
 dickrx.net
-dicksinhisan.us
-dicksinmyan.us
 dicksoncountyag.com
 dickwangdong.net
 dickwangdong.org
@@ -40400,7 +40390,6 @@ firema.cf
 firema.ga
 firema.ml
 firema.tk
-firemail.cc
 firemail.org.ua
 firemail.uz.ua
 firemailbox.club
@@ -45317,7 +45306,6 @@ goandrate.com
 goasfer.com
 goashmail.com
 goat.coach
-goat.si
 goaustralianow.com
 gob0u9.site
 gobaby.online
@@ -50302,7 +50290,6 @@ horrorplaybook.com
 horsebarninfo.com
 horsebrai.press
 horsebrow.email
-horsefucker.org
 horsepoops.info
 horseracing-betting.net
 horserashnesslumen.site
@@ -63889,8 +63876,6 @@ lovemytrail.org
 lovepdfmanuales.xyz
 loveplanetx.com
 loversalvagepains.site
-loves.dicksinhisan.us
-loves.dicksinmyan.us
 lovesea.gq
 lovesfire.club
 lovesoftware.net
@@ -67825,7 +67810,6 @@ memequeen.dev
 memequeen.fun
 memes.watch
 memescribe.com
-memeware.net
 memgrid.net
 memgrid.org
 memkottawaprofilebacks.com
@@ -72510,7 +72494,6 @@ nathangould.com
 natillas-shop-4u.ru
 national-alert.org
 national-escorts.co.uk
-national.shitposting.agency
 nationalartsstandard.org
 nationalassociationoftinyhouses.com
 nationalcbdcorporation.com
@@ -100747,7 +100730,6 @@ tfgphjqzkc.pl
 tfiadvocate.com
 tfq.us
 tftitem.com
-tfwno.gf
 tfzav6iptxcbqviv.cf
 tfzav6iptxcbqviv.ga
 tfzav6iptxcbqviv.gq
@@ -110563,7 +110545,6 @@ waibavic.ga
 waibavic.gq
 waibavic.ml
 waibavic.tk
-waifu.club
 waifufigures.com
 waikikieasthotel.com
 waikinyxt.site
@@ -110707,8 +110688,6 @@ wantisol.tk
 wantplay.site
 wantresult71.online
 wantresultkzn.ru
-wants.dicksinhisan.us
-wants.dicksinmyan.us
 wantsuccess.ru
 wanttocum.com
 wantwasherdryerparts.site


### PR DESCRIPTION
## Summary
Cock.li no longer provides registration and aims to be invite only email domain as it stated here [https://cock.li/register](https://cock.li/register).
By the way cock.li has never been a disposable email provider.

## Details
List of email domains from [cock.li home page](https://cock.li/)
- cock.li
- airmail.cc
- 420blaze.it
- aaathats3as.com
- cumallover.me
- goat.si
- horsefucker.org
- national.shitposting.agency
- tfwno.gf
- cock.lu
- cock.email
- firemail.cc
- memeware.net
- cocaine.ninja
- waifu.club
- dicksinhisan.us
- loves.dicksinhisan.us
- wants.dicksinhisan.us
- dicksinmyan.us
- loves.dicksinmyan.us
- wants.dicksinmyan.us

## Related:
#77 