### PR TITLE
remove mozmail.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -33750,7 +33750,6 @@ moza.pl
 mozej.com
 mozej.online
 mozillafirefox.tk
-mozmail.com
 mp-j.igg.biz
 mp.igg.biz
 mp3-cube.com


### PR DESCRIPTION
I'm the tech lead for [Firefox Relay](https://relay.firefox.com/). A few months ago, we took over the mozmail.com domain for our aliases. We are operating Relay with a number of features that I think mitigate the risks that these aliases pose:

* Bounces & deliver-ability - if our user disables an @mozmail.com alias, we DO NOT trigger a bounce. [We silently drop the email and return a harmless 404 from our HTTP webhook to SNS](https://github.com/mozilla/fx-private-relay/blob/1aae20dc8857316ee6b972442b4c8cb33ab016e4/emails/views.py#L298-L308).
* Anti-abuse protections - we limit our free users to 5 total aliases, and we rate-limit our premium customers so they cannot create large-scale throw-away aliases for abusive sign-ups and behaviors.

So, we'd like to have mozmail.com removed from this burner email providers list please.

Are there other protections people would like to see to be comfortable accepting @mozmail.com aliases?