### PR TITLE
added tradetnz.info (phishing domain as per https://www.csirt.gob.cl/…

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -50296,6 +50296,7 @@ tradersoffortune.com
 tradeseze.com
 tradeskins.ru
 tradeswallet.online
+tradetnz.info
 tradewithgreg.com
 tradewithrichard.com
 tradexan.cf


### PR DESCRIPTION
phishing domain as per [csirt.gob.cl](https://www.csirt.gob.cl/alertas/2cmv22-00378-01/).