### PR TITLE
remove xwaretech domains

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -55853,10 +55853,6 @@ xv9u9m.com
 xvnc.net
 xvpz6c.us
 xvx.us
-xwaretech.com
-xwaretech.info
-xwaretech.net
-xwaretech.tk
 xwdmoe.cf
 xwtaudcha.cf
 xww.ro


### PR DESCRIPTION
Previously pointed to mailinator,
now used for my company.