### PR TITLE
Remove Argentinian country domain

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -12636,7 +12636,6 @@ columbusnm.net
 columbusquote.com
 com-ma.net
 com-mobilealert.com
-com.ar
 com.ninja
 com3b.com
 comam.ru


### PR DESCRIPTION
This is the official domain of Argentina and not a burner domain.