### PR TITLE
Update emails.txt to remove ubicloud.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -13030,7 +13030,6 @@ ualusa.com
 uasalbany.info
 uatop.in
 uber-mail.com
-ubicloud.com
 ubismail.net
 ubm.md
 ubmail.com


### PR DESCRIPTION
Ubicloud.com is our startup's domain and has its SPF, DKIM, and DMARC records properly configured.

Every time we need to sign up to a SaaS service such as Slack, Heroku, levels.fyi, etc., we need to contact their dev team. This pull request fixes the source blacklist instead.