### PR TITLE
Add 40 new domains

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -863,6 +863,7 @@ akekee.com
 akerd.com
 akgq701.com
 akk.ro
+akmail.in
 akmaila.org
 aksarayorospulari.xyz
 aktiefmail.nl
@@ -1594,6 +1595,9 @@ bbdd.info
 bbestssafd.com
 bbetweenj.com
 bbhost.us
+bbitf.com
+bbitj.com
+bbitq.com
 bbox.com
 bboygarage.com
 bbq59.xyz
@@ -1615,6 +1619,7 @@ bdf343rhe.de
 bdmuzic.pw
 be-breathtaking.net
 beach-homes.com
+beaconmessenger.com
 bean.farm
 beanlignt.com
 bearsarefuzzy.com
@@ -1720,6 +1725,7 @@ bfremails.com
 bgtmail.com
 bgx.ro
 bgzbbs.com
+bheps.com
 bho.hu
 bho.kr
 bhss.de
@@ -1941,6 +1947,7 @@ boxformail.in
 boximail.com
 boxless.info
 boxmail.co
+boxmail.lol
 boxmailbox.club
 boxomail.live
 boxppy.ru
@@ -2040,6 +2047,7 @@ budrem.com
 buffaloquote.com
 buffemail.com
 bug.cl
+bugfoo.com
 bugmenever.com
 bugmenot.com
 building-bridges.com
@@ -2496,6 +2504,7 @@ citylightsart.com
 cityroyal.org
 citywinetour.com
 ciudad-activa.com
+civikli.com
 civilium.com
 civoo.com
 civvic.ro
@@ -2822,6 +2831,7 @@ creo.cloudns.cc
 creo.ctu.edu.gr
 crepeau12.com
 crezjumevakansii20121.cz.cc
+cringemonster.com
 cristalin.ru
 crm-mebel.ru
 crmrc.us
@@ -3180,6 +3190,7 @@ dbook.pl
 dbunker.com
 dc-business.com
 dcbarr.com
+dcctb.com
 dcemail.com
 dcibb.xyz
 dctm.de
@@ -3409,6 +3420,7 @@ dev-null.ga
 dev-null.gq
 dev-null.ml
 devcard.com
+developermail.com
 developmentwebsite.co.uk
 devere-malta.com
 devinmariam.coayako.top
@@ -3670,6 +3682,7 @@ dons.com
 dontreg.com
 dontsendmespam.de
 dooboop.com
+doojazz.com
 doolanlawoffice.com
 doommail.com
 doquier.tk
@@ -4176,6 +4189,7 @@ eraseo.com
 erasf.com
 erectiledysfunctionpillsest.com
 erectiledysfunctionpillsonx.com
+ereplyzy.com
 erermail.com
 erertmail.com
 erexcolbart.xyz
@@ -4316,6 +4330,7 @@ extanewsmi.zzux.com
 extic.com
 extra-breast.info
 extra.oscarr.nl
+extracurricularsociety.com
 extrarole.com
 extravagandideas.com
 extravagant.pl
@@ -4493,6 +4508,7 @@ feedbackadvantage.com
 feedspot.com
 feedspotmailer.com
 fejm.pl
+femailtor.com
 femalefemale.com
 fenceve.com
 fengting01.mygbiz.com
@@ -4507,6 +4523,7 @@ fewdaysmoney.com
 fexbox.org
 fexbox.ru
 fexpost.com
+fextemp.com
 feyerhermt.ws
 ff-flow.com
 ffamilyaa.com
@@ -4726,6 +4743,7 @@ foxwoods.com
 foy.kr
 fpf.team
 fq1my2c.com
+fr.cr
 fr.nf
 fr33mail.info
 fractalauto.com
@@ -4855,6 +4873,7 @@ fuirio.com
 fukaru.com
 fuktard.co.in
 fukurou.ch
+fullangle.org
 fulledu.ru
 fullen.in
 fuluj.com
@@ -4872,6 +4891,7 @@ fursuit.info
 furusato.tokyo
 furzauflunge.de
 fusskitzler.de
+futuramind.com
 futuraseoservices.com
 futurebuckets.com
 futuristicplanemodels.com
@@ -6001,9 +6021,11 @@ imprisonedwithisis.com
 imstations.com
 imul.info
 in-ulm.de
+in2reach.com
 in4mail.net
 in5minutes.net
 inaby.com
+inactivemachine.com
 inamail.com
 inappmail.com
 inbaca.com
@@ -6458,6 +6480,7 @@ jnswritesy.com
 jnxjn.com
 job.craigslist.org
 jobbikszimpatizans.hu
+jobbrett.com
 jobcheetah.com
 jobdesk.org
 joblike.com
@@ -7230,6 +7253,7 @@ kykareku.ru
 kylemaguire.com
 kylemorin.co
 kyois.com
+kzccv.com
 kzcontractors.com
 l-c-a.us
 l-okna.ru
@@ -7312,6 +7336,7 @@ lakqs.com
 lal.kr
 lalala.fun
 lam0k.com
+lamasticots.com
 lambda.uniform.thefreemail.top
 lambdaecho.webmailious.top
 lamdx.com
@@ -7325,6 +7350,7 @@ laokzmaqz.tech
 largelift.com
 larisia.com
 larjem.com
+larland.com
 laserevent.com
 lasixprime.com
 last-chance.pro
@@ -8427,6 +8453,7 @@ megogonett.ru
 mehditech.info
 mehrpoy.ir
 meibokele.com
+meidecn.com
 meimanbet.com
 meineinkaufsladen.de
 meinspamschutz.de
@@ -8900,6 +8927,7 @@ mycrazyemail.com
 mycsbin.site
 mydb.com
 myde.ml
+mydefipet.live
 mydemo.equipment
 mydigitallogic.com
 myecho.es
@@ -10029,6 +10057,7 @@ pitonresources.org
 pivo-bar.ru
 pixego.com
 pixeltips.xyz
+pixiil.com
 pizza25.ga
 pizzajunk.com
 pjjkp.com
@@ -10472,6 +10501,7 @@ qege.site
 qeps.de
 qhqhidden.com
 qibl.at
+qiott.com
 qipaomei.com
 qipmail.net
 qiq.us
@@ -11051,6 +11081,7 @@ sabrestlouis.com
 sac-zbcg.com
 sackboii.com
 sadd.us
+saeoil.com
 safaat.cf
 safe-mail.gq
 safe-mail.net
@@ -11573,6 +11604,7 @@ smart-mail.top
 smartbusiness.me
 smartgrid.com
 smartkeeda.net
+smartnator.com
 smartpaydayonline.com
 smartplaygame.com
 smarttalent.pw
@@ -11751,6 +11783,7 @@ sonyymail.com
 soodmail.com
 soodomail.com
 soodonims.com
+soombo.com
 soon.it
 soowz.com
 soozoop.com
@@ -12220,6 +12253,7 @@ swinginggame.com
 sworda.com
 swype.dev
 syfilis.ru
+syinxun.com
 sylvannet.com
 sylwester.podhale.pl
 symatoys.ru
@@ -12340,6 +12374,8 @@ tcases.com
 tchatrencontrenc.com
 tchatroulette.eu
 tchatsenegal.com
+tcwlm.com
+tcwlx.com
 tdbusinessfinancing.com
 tdcryo.com
 tdtda.com
@@ -12548,6 +12584,7 @@ theeasymail.com
 theemailaccount.com
 theemailadress.com
 theexitgroup.com
+theeyeoftruth.com
 thefairyprincessshop.com
 thefxpro.com
 theindiaphile.com
@@ -12717,6 +12754,7 @@ tmpeml.info
 tmpjr.me
 tmpmail.net
 tmpmail.org
+tmpx.sa.com
 to200.com
 toastmatrix.com
 toastsum.com
@@ -12829,6 +12867,7 @@ tp-qa-mail.com
 tpaglucerne.dnset.com
 tpass.xyz
 tpmail.top
+tpwlb.com
 tq3.pl
 tqc-sheen.com
 tqoai.com
@@ -13909,6 +13948,7 @@ wuespdj.xyz
 wuhl.de
 wumbo.co
 wupics.com
+wuuvo.com
 wuzhizheng.mygbiz.com
 wuzup.net
 wuzupmail.net


### PR DESCRIPTION
New domains:

bbitf.com
doojazz.com
saeoil.com
wuuvo.com
jobbrett.com
fr.cr
lamasticots.com
developermail.com
bugfoo.com
ereplyzy.com
soombo.com
dcctb.com
smartnator.com
bbitj.com
tpwlb.com
akmail.in
kzccv.com
civikli.com
femailtor.com
boxmail.lol
pixiil.com
qiott.com
beaconmessenger.com
tcwlm.com
bheps.com
tmpx.sa.com
syinxun.com
fullangle.org
meidecn.com
theeyeoftruth.com
in2reach.com
larland.com
tcwlx.com
bbitq.com
cringemonster.com
fextemp.com
extracurricularsociety.com
mydefipet.live
inactivemachine.com
futuramind.com