### PR TITLE
remove cognata.com from list

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -2638,7 +2638,6 @@ codyting.com
 coffeepancakewafflebacon.com
 coffeetimer24.com
 cognalsearch.com
-cognata.com
 coieo.com
 coin-host.net
 coin-hub.net


### PR DESCRIPTION
Might have been a burner email provider in the past but no longer is https://www.cognata.com/company/