### PR TITLE
Remove swatch.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -13096,7 +13096,6 @@ swankyfood.us
 swanticket.com
 swap-crypto.site
 swapinsta.com
-swatch.com
 sweatmail.com
 sweemri.com
 sweepstakesforme.com


### PR DESCRIPTION
Hi, it seems as if the checker aggregated the domain swatch.com which is the official domain of the well known Swiss clock manufacture. Please remove the domain from the list.

Thanks!