### PR TITLE
remove nate.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -13545,7 +13545,6 @@ naszelato.pl
 natachasteven.com
 natafaka.online
 natashaferre.com
-nate.com
 nationalgardeningclub.com
 nationwidedebtconsultants.co.uk
 naturalnoemylo.ru


### PR DESCRIPTION
https://www.nate.com/ is a south korean web portal with millions of users, like a yahoo.com