### PR TITLE
Remove hyatt.com from list

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -8950,7 +8950,6 @@ hxqmail.com
 hxsni.com
 hxvxxo1v8mfbt.cf
 hyab.de
-hyatt.com
 hybridmc.net
 hycehyxyxu.today
 hydraza.com


### PR DESCRIPTION
Hyatt.com is the hotel's corporate domain