### PR TITLE
Remove skiff.com - not burner address

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -17408,7 +17408,6 @@ skdjfmail.com
 skdl.de
 skeefmail.com
 skeet.software
-skiff.com
 skifrance.website
 skillfare.com
 skillion.org


### PR DESCRIPTION
Addresses https://github.com/wesbos/burner-email-providers/issues/423. 