### PR TITLE
add maskmy.id

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -12429,6 +12429,7 @@ maskbistsmar.ga
 maskedmails.com
 maskelimaymun.ga
 maskmail.net
+maskmy.id
 masks-muzik.ru
 maslicov.biz
 masongazard.com


### PR DESCRIPTION
Provider is https://skiff.com/quick-alias and it's actually subdomains, each user can generate their own subdomain. I tested it, very easy.

The page title of https://skiff.com/quick-alias is "Quick alias burner email address". In the HTML I see
```
<meta name="description" content="Secure and quick-to-create burner email addresses with Skiff! Maintain your p
```

There is a browser plugin https://github.com/irazasyed/email-masker to create one email per website, skiff.com's twitter account promoted it, the github repository is tagged as 'burner-email'


In https://github.com/wesbos/burner-email-providers/issues/423 the CEO argues their main skiff.com domain is not burner email provider. I think that domain might not, the company is though.

![image](https://github.com/wesbos/burner-email-providers/assets/3727288/149c904b-872e-437c-b6a0-0924386e8220)

![image](https://github.com/wesbos/burner-email-providers/assets/3727288/353a4e24-3196-4f86-b2f8-282c6c0f89c9)
