### PR TITLE
remove xwaretech domains (again)

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -21294,9 +21294,6 @@ xv9u9m.com
 xvector.org
 xvlinjury.com
 xvx.us
-xwaretech.com
-xwaretech.info
-xwaretech.net
 xwgiant.com
 xwiekhduzw.ga
 xwkqguild.com


### PR DESCRIPTION
Removed before in:
https://github.com/wesbos/burner-email-providers/pull/373

They were mistakenly added back in this PR:
https://github.com/wesbos/burner-email-providers/pull/395