### PR TITLE
Add mailify.org

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -12516,7 +12516,6 @@ mailhubpros.com
 mailhz.me
 maili.fun
 mailify.org
-mailify.org
 mailimail.com
 mailimate.com
 mailimpulse.com

--- a/emails.txt
+++ b/emails.txt
@@ -12515,6 +12515,7 @@ mailhub24.com
 mailhubpros.com
 mailhz.me
 maili.fun
+mailify.org
 mailimail.com
 mailimate.com
 mailimpulse.com

--- a/emails.txt
+++ b/emails.txt
@@ -12516,6 +12516,7 @@ mailhubpros.com
 mailhz.me
 maili.fun
 mailify.org
+mailify.org
 mailimail.com
 mailimate.com
 mailimpulse.com


### PR DESCRIPTION
[mailify.org](mailify.org) is "Temporary & disposable email system".