### PR TITLE
Add losvtn.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -12593,6 +12593,7 @@ lortemail.dk
 losemymail.com
 lostfilmhd1080.ru
 lostlanguage.com
+losvtn.com
 lotteryfordream.com
 lotto-wizard.net
 lottoresults.ph


### PR DESCRIPTION
adding `losvtn.com` domain used by [temp-mail.org](https://temp-mail.org/)