### PR TITLE
Github actions - upgrade to nodejs 20

### DIFF
--- a/.github/workflows/dedupe.yaml
+++ b/.github/workflows/dedupe.yaml
@@ -9,7 +9,7 @@ jobs:
   dedupe:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}


### PR DESCRIPTION
Github Actions reported "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3"