### PR TITLE
add emailhook.site

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -6345,6 +6345,7 @@ emailgenerator.de
 emailgo.de
 emailgotty.xyz
 emailhearing.com
+emailhook.site
 emailhost99.com
 emailias.com
 emailigo.de


### PR DESCRIPTION
An alias of https://webhook.site "generates free, unique URLs and e-mail addresses and lets you see everything that’s sent there instantly."

https://docs.webhook.site/news.html#15-april-2024 "now uses the domain emailhook.site for email receiving and sending"