### PR TITLE
add mxscout.com and related domains

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -6214,6 +6214,7 @@ el-x.tech
 el.cash
 elaineshoes.com
 elastit.com
+elatter.com
 elaven.cf
 elcajonrentals.com
 elcarin.store
@@ -11626,6 +11627,7 @@ letshack.cc
 letsmail9.com
 letsrelay.com
 lettersfxj.com
+lettershield.com
 letthemeatspam.com
 lettrs.email
 leupus.com
@@ -12401,6 +12403,7 @@ mail.rentaen.com
 mail.ricorit.com
 mail.roborena.com
 mail.rohoza.com
+mail.secretmail.net
 mail.sentrau.com
 mail.seosnaps.com
 mail.sfpixel.com
@@ -12547,6 +12550,7 @@ mailcua.cyou
 mailcua.store
 mailcuk.com
 mailcupp.com
+mailcurity.com
 maildax.me
 mailde.de
 mailde.info
@@ -13943,6 +13947,7 @@ mxcdd.com
 mxclip.com
 mxfuel.com
 mxgsby.com
+mxscout.com
 mxvia.com
 my-fashion.online
 my-great-email-address.top


### PR DESCRIPTION
Add mxscout.com and related domains

Root: [mxscout.com](https://verifymail.io/domain/mxscout.com) is used by [AdGuard Temp Mail](https://adguard.com/en/adguard-temp-mail/overview.html)

Related:
[elatter.com](https://verifymail.io/domain/elatter.com)
[lettershield.com](https://verifymail.io/domain/lettershield.com)
[mailcurity.com](https://verifymail.io/domain/mailcurity.com)
[mail.secretmail.net](https://verifymail.io/domain/mail.secretmail.net)

