### PR TITLE
Remove dumplingai.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -6022,7 +6022,6 @@ dummymails.cc
 dumoac.net
 dump-email.info
 dumpandjunk.com
-dumplingai.com
 dumpmail.de
 dumpyemail.com
 duncancorp.usa.cc


### PR DESCRIPTION
We recently bought dumplingai.com for our organization and launched a SaaS.
Our service has nothing to do with disposable or temporary emails.

Let me know if any more information is needed :) 


