### PR TITLE
Removing Cheezoo.com from list

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -4658,7 +4658,6 @@ cheekyart.net
 cheerclass.com
 cheesethecakerecipes.com
 cheetabet12.com
-cheezoo.com
 cheezy.cf
 chefscrest.com
 chehov-beton-zavod.ru


### PR DESCRIPTION
Cheezoo.com is a legitimate photography website. Please remove from list.