### PR TITLE
remove 5 domains based on github issue reports

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -4142,7 +4142,6 @@ c.nut.emailfake.nut.cc
 c.theplug.org
 c0ndetzleaked.com
 c1oramn.com
-c2.hu
 c21rd.site
 c2rnm.anonbox.net
 c306u.com
@@ -9250,7 +9249,6 @@ gdatingq.com
 gdcmedia.info
 gdcpx.anonbox.net
 gddao.com
-gdf.it
 gdfgsd.cloud
 gdienter.com
 gdiey.freeml.net
@@ -12598,7 +12596,6 @@ kenfern.com
 kenhbanme.com
 kenhdeals.com
 kennebunkportems.org
-kennedy808.com
 kennethpaskett.name
 kennie.club
 kennyet.com
@@ -13579,7 +13576,6 @@ laurelmountainmustang.com
 laurieingramdesign.com
 lauxanh.live
 lauxitupvw.ga
-lavabit.com
 lavendel24.de
 lavp.de
 lawlita.com
@@ -15178,7 +15174,6 @@ mailtemp.net
 mailtemp.org
 mailtemporaire.com
 mailtemporaire.fr
-mailtime.com
 mailtmk.com
 mailto.buzz
 mailto.plus


### PR DESCRIPTION
The domains in the github issues look legit. Combining all into a single PR to make it easy to merge. I'm not affiliated with any of the domains.

closes https://github.com/wesbos/burner-email-providers/issues/511
closes https://github.com/wesbos/burner-email-providers/issues/510
closes https://github.com/wesbos/burner-email-providers/issues/507
closes https://github.com/wesbos/burner-email-providers/issues/481
closes https://github.com/wesbos/burner-email-providers/issues/478
