### PR TITLE
Remove ikmail.com, it's no longer a temp mail domain

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -11197,7 +11197,6 @@ ikbenspamvrij.nl
 ikewe.com
 iki.kr
 ikl.dropmail.me
-ikmail.com
 ikowat.com
 ikq.emlpro.com
 iku.emlpro.com

--- a/prune/alive.txt
+++ b/prune/alive.txt
@@ -11671,7 +11671,6 @@ ii47.com
 ilovespam.com
 imailbox.org
 ilovecorgistoo.com
-ikmail.com
 ildz.com
 iljmail.com
 imaild.com


### PR DESCRIPTION
https://news.infomaniak.com/en/create-free-email-address/
https://github.com/disposable/disposable/pull/211

see e.g. https://github.com/FGRibreau/mailchecker/commit/d129b5eef5d053046cfc46e42a99b4457ed6309d.
i couldn't find where this was originally coming from, it seems that it was a temp mail domain in the past but not anymore.
it appears to be a regular freemailer now.