### PR TITLE
inbox.com isn't a disposable email

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -11310,7 +11310,6 @@ inbilling.be
 inbound.plus
 inbov03.com
 inbox-me.top
-inbox.com
 inbox.si
 inbox.vin
 inbox2.info


### PR DESCRIPTION
This PR removes inbox.com from the disposable email list. Based on a review of [inbox.com](https://www.inbox.com/), it appears to be a legitimate, non-disposable email provider.