### PR TITLE
remove za.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -26868,7 +26868,6 @@ z6enr.anonbox.net
 z7az14m.com.com
 z86.ru
 z9.z9.cloudns.nz
-za.com
 za72p.com
 zaa.org
 zaab.de


### PR DESCRIPTION
za.com itself doesn't have content. The (London based) registrar sells subdomains. I can understand if a subdomain gets added to the list but *.za.com seems too broad.

https://www.name.com/domains/za.com