### PR TITLE
fix: remove forwardemail.net from burner email providers list

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -8768,7 +8768,6 @@ forumbens.website
 forumbens.xyz
 forward.cat
 forward4families.org
-forwardemail.net
 foshata.com
 fosil.pro
 foster137.store


### PR DESCRIPTION
forwardemail.net is a legitimate, paid, open-source email service (https://forwardemail.net) providing IMAP, SMTP, and CalDAV email hosting for custom domains. It is not a disposable/burner email provider.

This false positive causes services that consume this list (e.g. Netlify, Disposable) to block signups from forwardemail.net users.

We support 3M+ domains and notable users such as U.S. Naval Academy, Canonical (Ubuntu), Netflix Games, The Linux Foundation, Disney, jQuery, UMD, Cambridge University, UW, Tufts, and more.