### PR TITLE
Add endtest-mail.io as disposable email domain

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -7630,6 +7630,7 @@ encuentra24.app
 encuestan.com
 encuestas.live
 endosferes.ru
+endtest-mail.io
 endymion-numerique.com
 energiadeportugal.com
 enersets.com


### PR DESCRIPTION
This PR adds endtest-mail.io as a disposable email provider domain.

Reference: https://endtest.io/mailbox