### PR TITLE
Removal request: zamana.com legitimate corporate domain, listing predates current ownership

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -26885,7 +26885,6 @@ zakkaas.com
 zaknama.com
 zaktouni.fr
 zalzl.com
-zamana.com
 zamaneta.com
 zamburu.com
 zamd7.anonbox.net


### PR DESCRIPTION
Hi, please remove zamana.com from the list. zamana.com is the corporate email domain of Zamana Inc.

The domain (registered since 2004) was acquired by the company in October 2025; any disposable-email activity predates our ownership. It was first flagged around 2019, years before the company existed.

There is no public email signup or address-generation service on this domain today.

Current setup, publicly verifiable: business email on Google Workspace (MX: smtp.google.com), published SPF and DMARC.

The stale listing is blocking employees from registering for services.

Happy to provide further verification. Thank you!

domain marked safe on https://verifymail.io/domain/zamana.com
<img width="1267" height="937" alt="image" src="https://github.com/user-attachments/assets/e86fc5b0-e308-4511-a3c4-df6cc7b2e623" />
