### PR TITLE
Remove stanbondsa.com.au false positive

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -22216,7 +22216,6 @@ staffprime.com
 stalnoj.ru
 stamberg.nl
 stanastroo.ml
-stanbondsa.com.au
 stanford-edu.cf
 stanford-university.education
 stanfordujjain.com


### PR DESCRIPTION
## What changed

Removed `stanbondsa.com.au` from `emails.txt`.

## Why

This is a false positive. Stan Bond is an established Australian business using this domain for ordinary, long-lived business email. The domain has an active public website and its MX records point to Google Workspace (`aspmx.l.google.com` and Google backup MX hosts); it does not provide temporary or burner mailboxes.

The list originally incorporated Mailchecker data in [`add FGRibreau/mailchecker list`](https://github.com/wesbos/burner-email-providers/commit/87c6b5a36508982f19e934da78707d87c797e902). In Mailchecker, this domain came from a 2019 Stop Forum Spam import. Stop Forum Spam's [current domain report](https://www.stopforumspam.com/domain/stanbondsa.com.au) now says the domain does not appear in its database. The only remaining historical statistics are 23 reports clustered between 11 May and 16 June 2012, with no later activity.

The stale classification is causing legitimate users of the domain to be rejected by signup forms that consume disposable-domain lists.

## Validation

- The diff changes only `emails.txt` and removes exactly one entry.
- `stanbondsa.com.au` is no longer present in the source list.
- The neighbouring entries remain alphabetically ordered.
- Live website check returns HTTP 200.
- Current MX, SPF and DMARC records confirm an actively managed Google Workspace business domain.
